### PR TITLE
Paywall Premium Content

### DIFF
--- a/_posts/dynamic-routing.md
+++ b/_posts/dynamic-routing.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/jj.jpeg'
 ogImage:
   url: '/assets/blog/dynamic-routing/cover.jpg'
+premium: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/hello-world.md
+++ b/_posts/hello-world.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/tim.jpeg'
 ogImage:
   url: '/assets/blog/hello-world/cover.jpg'
+premium: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/preview.md
+++ b/_posts/preview.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/joe.jpeg'
 ogImage:
   url: '/assets/blog/preview/cover.jpg'
+premium: false
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -11,6 +11,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  premium?: boolean
 }
 
 const HeroPost = ({
@@ -20,6 +21,7 @@ const HeroPost = ({
   excerpt,
   author,
   slug,
+  premium
 }: Props) => {
   return (
     <section>
@@ -39,6 +41,9 @@ const HeroPost = ({
         </div>
         <div>
           <p className="text-lg leading-relaxed mb-4">{excerpt}</p>
+          { premium && (
+            <p className="text-lg leading-relaxed mb-4">Premium Article</p>
+          )}
           <Avatar name={author.name} picture={author.picture} />
         </div>
       </div>

--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -21,6 +21,7 @@ const MoreStories = ({ posts }: Props) => {
             author={post.author}
             slug={post.slug}
             excerpt={post.excerpt}
+            premium={post.premium}
           />
         ))}
       </div>

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -11,6 +11,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  premium?: boolean
 }
 
 const PostPreview = ({
@@ -20,6 +21,7 @@ const PostPreview = ({
   excerpt,
   author,
   slug,
+  premium
 }: Props) => {
   return (
     <div>
@@ -35,6 +37,9 @@ const PostPreview = ({
         <DateFormatter dateString={date} />
       </div>
       <p className="text-lg leading-relaxed mb-4">{excerpt}</p>
+      { premium && (
+        <p className="text-lg leading-relaxed mb-4">Premium Article</p>
+      )}
       <Avatar name={author.name} picture={author.picture} />
     </div>
   )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,6 +31,7 @@ const Index = ({ allPosts }: Props) => {
               author={heroPost.author}
               slug={heroPost.slug}
               excerpt={heroPost.excerpt}
+              premium={heroPost.premium}
             />
           )}
           {morePosts.length > 0 && <MoreStories posts={morePosts} />}
@@ -50,6 +51,7 @@ export const getStaticProps = async () => {
     'author',
     'coverImage',
     'excerpt',
+    'premium'
   ])
 
   return {

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -11,6 +11,7 @@ import Head from 'next/head'
 import { CMS_NAME } from '../../lib/constants'
 import markdownToHtml from '../../lib/markdownToHtml'
 import PostType from '../../types/post'
+import { useEffect, useState } from 'react'
 
 type Props = {
   post: PostType
@@ -19,11 +20,58 @@ type Props = {
 }
 
 const Post = ({ post, morePosts, preview }: Props) => {
+  const { premium } = post;
   const router = useRouter()
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage statusCode={404} />
   }
+
+  
+
+  
+  const evaluateAuth = (username: string, password: string) => {
+    if (username && username === "foo" && password && password === "bar") {
+      return true;
+    }
+    return false;
+  }
+
+  const [loggedIn, setLoggedIn] = useState(false); // read from local storage
+  const [user, setUsername] = useState("");
+  const [pass, setPassword] = useState("");
+  const [logInError, setLoginError] = useState(false);
+
+  const determineLoggedInState = () => {
+    if (localStorage.getItem('blog-auth' as string)) {
+      const { username, password } = JSON.parse(localStorage.getItem('blog-auth') as string);
+      if (username && password) {
+        return evaluateAuth(username, password);
+      }
+    }
+    return false;
+  }
+
+
+  useEffect(() => {
+    setLoggedIn(determineLoggedInState()); 
+  });
+
+  const handleSubmit = () => {
+    if (user && pass) {
+      const passesAuth = evaluateAuth(user, pass);
+      if (passesAuth) {
+        localStorage.setItem('blog-auth', JSON.stringify({username: user, password: pass}));
+        setLoggedIn(passesAuth);
+        setLoginError(false);
+      } else {
+        setLoginError(true);
+      }
+    }
+  }
+
   return (
+    
+    ((premium && loggedIn) || !premium) ? (
     <Layout preview={preview}>
       <Container>
         <Header />
@@ -50,6 +98,24 @@ const Post = ({ post, morePosts, preview }: Props) => {
         )}
       </Container>
     </Layout>
+    ) : (
+      <form onSubmit={handleSubmit}>
+        {
+          logInError && (
+            <p>Login not valid</p>
+          )
+        }
+        <label>
+          UserName:
+          <input type="text" name="name" onChange={(e) => setUsername(e.target.value as string)}/>
+        </label>
+        <label>
+          Password:
+          <input type="text" name="name" onChange={(e) => setPassword(e.target.value as string)}/>
+        </label>
+        <input type="submit" value="Submit" / >
+      </form>
+    )
   )
 }
 
@@ -70,6 +136,7 @@ export async function getStaticProps({ params }: Params) {
     'content',
     'ogImage',
     'coverImage',
+    'premium'
   ])
   const content = await markdownToHtml(post.content || '')
 
@@ -77,7 +144,7 @@ export async function getStaticProps({ params }: Params) {
     props: {
       post: {
         ...post,
-        content,
+        content
       },
     },
   }

--- a/types/post.ts
+++ b/types/post.ts
@@ -11,6 +11,7 @@ type PostType = {
     url: string
   }
   content: string
+  premium?: boolean
 }
 
 export default PostType


### PR DESCRIPTION
Following Changes:

1) Added "premium" as part of the metadata for blogs. Optional boolean.
2) Added a lightweight login form that stores auth credentials in local storage, if auth creds don't already exist. If the auth creds exist already (i.e. user has already logged in), then the website should render articles as normal. If not auth creds existing, user is prompted to provide user creds and should the creds match the (hardcoded) values in the front end, then the credentials are stored in local storage.
3) "Premium Article" text tag on the articles -- with additional time, my plan would be to look into Tailwind's component library to find a "Locked" icon to be rendered instaed of the tag. This tag is rendered based on the "premium" attribute of the blog