### PR TITLE
Paywall changes for take-home assignment

### DIFF
--- a/_posts/dynamic-routing.md
+++ b/_posts/dynamic-routing.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/jj.jpeg'
 ogImage:
   url: '/assets/blog/dynamic-routing/cover.jpg'
+premium: 1
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/hello-world.md
+++ b/_posts/hello-world.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/tim.jpeg'
 ogImage:
   url: '/assets/blog/hello-world/cover.jpg'
+premium: 1
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/preview.md
+++ b/_posts/preview.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/joe.jpeg'
 ogImage:
   url: '/assets/blog/preview/cover.jpg'
+premium: 0
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,13 +1,23 @@
 import Link from 'next/link'
+import LoginHeader from '../components/loginheader'
 
-const Header = () => {
+type Props = {
+  callbackURL: string
+}
+
+const Header = ({callbackURL}: Props) => {
   return (
-    <h2 className="text-2xl md:text-4xl font-bold tracking-tight md:tracking-tighter leading-tight mb-20 mt-8">
-      <Link href="/">
-        <a className="hover:underline">Blog</a>
-      </Link>
-      .
-    </h2>
+    <>
+      <LoginHeader callbackURL={callbackURL} />
+      <h2 className="text-2xl md:text-4xl font-bold tracking-tight md:tracking-tighter leading-tight mb-20 mt-8">
+        <Link href="/">
+          <a className="hover:underline">
+            Blog
+          </a>
+        </Link>
+        .
+      </h2>
+    </>
   )
 }
 

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -11,6 +11,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  premium: number
 }
 
 const HeroPost = ({
@@ -20,6 +21,7 @@ const HeroPost = ({
   excerpt,
   author,
   slug,
+  premium
 }: Props) => {
   return (
     <section>
@@ -35,6 +37,7 @@ const HeroPost = ({
           </h3>
           <div className="mb-4 md:mb-0 text-lg">
             <DateFormatter dateString={date} />
+            {premium == 1 && <p>Premium</p>}
           </div>
         </div>
         <div>

--- a/components/loginheader.tsx
+++ b/components/loginheader.tsx
@@ -16,7 +16,7 @@ const LoginHeader = ({ callbackURL }: Props) => {
             setUserName(cookies['user'])
             setButtontext("Logout")
         }
-    })
+    }, [cookies])
     return <Link href={{ pathname: "/login", query: {callbackURL: callbackURL} }} as="/login">
         <a>
             <div className="flex justify-end pt-2 mb-2">

--- a/components/loginheader.tsx
+++ b/components/loginheader.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import Avatar from '../components/avatar'
+import { useCookies } from 'react-cookie'
+import { useState, useEffect } from 'react'
+
+type Props = {
+    callbackURL: string
+}
+
+const LoginHeader = ({ callbackURL }: Props) => {
+    const [cookies] = useCookies(['user'])
+    const [username, setUserName] = useState("Guest")
+    const [buttontext, setButtontext] = useState("Login")
+    useEffect(() => {
+        if (cookies['user'] !== undefined) {
+            setUserName(cookies['user'])
+            setButtontext("Logout")
+        }
+    })
+    return <Link href={{ pathname: "/login", query: {callbackURL: callbackURL} }} as="/login">
+        <a>
+            <div className="flex justify-end pt-2 mb-2">
+                <Avatar name={username} picture="/assets/blog/authors/jj.jpeg" />
+                <div className="flex items-center ml-4">{buttontext}</div>
+            </div>
+        </a>
+    </Link>
+}
+
+export default LoginHeader

--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -21,6 +21,7 @@ const MoreStories = ({ posts }: Props) => {
             author={post.author}
             slug={post.slug}
             excerpt={post.excerpt}
+            premium={post.premium}
           />
         ))}
       </div>

--- a/components/post-header.tsx
+++ b/components/post-header.tsx
@@ -9,14 +9,16 @@ type Props = {
   coverImage: string
   date: string
   author: Author
+  premium: number
 }
 
-const PostHeader = ({ title, coverImage, date, author }: Props) => {
+const PostHeader = ({ title, coverImage, date, author, premium }: Props) => {
   return (
     <>
       <PostTitle>{title}</PostTitle>
       <div className="hidden md:block md:mb-12">
         <Avatar name={author.name} picture={author.picture} />
+        {premium == 1 && <p>Premium</p>}
       </div>
       <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage title={title} src={coverImage} />

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -11,6 +11,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  premium: number
 }
 
 const PostPreview = ({
@@ -20,6 +21,7 @@ const PostPreview = ({
   excerpt,
   author,
   slug,
+  premium,
 }: Props) => {
   return (
     <div>
@@ -33,6 +35,7 @@ const PostPreview = ({
       </h3>
       <div className="text-lg mb-4">
         <DateFormatter dateString={date} />
+        {premium == 1 && <p>Premium</p>}
       </div>
       <p className="text-lg leading-relaxed mb-4">{excerpt}</p>
       <Avatar name={author.name} picture={author.picture} />

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@tailwindcss/forms": "^0.5.3",
     "classnames": "2.3.1",
     "date-fns": "2.21.3",
     "gray-matter": "4.0.3",
     "next": "latest",
     "react": "^17.0.2",
+    "react-cookie": "^4.1.1",
     "react-dom": "^17.0.2",
     "remark": "13.0.0",
     "remark-html": "13.0.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,9 @@
 import { AppProps } from 'next/app'
 import '../styles/index.css'
+import { CookiesProvider } from 'react-cookie'
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return <CookiesProvider>
+    <Component {...pageProps} />
+  </CookiesProvider>
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,6 +7,7 @@ import { getAllPosts } from '../lib/api'
 import Head from 'next/head'
 import { CMS_NAME } from '../lib/constants'
 import Post from '../types/post'
+import LoginHeader from '../components/loginheader'
 
 type Props = {
   allPosts: Post[]
@@ -22,6 +23,7 @@ const Index = ({ allPosts }: Props) => {
           <title>Next.js Blog Example with {CMS_NAME}</title>
         </Head>
         <Container>
+          <LoginHeader callbackURL="/" />
           <Intro />
           {heroPost && (
             <HeroPost
@@ -31,6 +33,7 @@ const Index = ({ allPosts }: Props) => {
               author={heroPost.author}
               slug={heroPost.slug}
               excerpt={heroPost.excerpt}
+              premium={heroPost.premium}
             />
           )}
           {morePosts.length > 0 && <MoreStories posts={morePosts} />}
@@ -50,6 +53,7 @@ export const getStaticProps = async () => {
     'author',
     'coverImage',
     'excerpt',
+    'premium',
   ])
 
   return {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -14,7 +14,7 @@ const Login = () => {
         event.preventDefault()
         if (userName === 'Admin' && password === "admin123") {
             setErrorMsg("")
-            setCookie('user', userName, { path: '/' })
+            setCookie('user', userName, { path: '/', secure: process.env.NODE_ENV === 'production' })
             router.replace(callbackURL)
         }
         setErrorMsg("Invalid credentials!")
@@ -48,6 +48,7 @@ const Login = () => {
                         </div>
                         <div>
                             <button type="submit" className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Sign in</button>
+                            <button onClick={() => router.replace("/")} className="flex w-full mt-4 justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Home</button>
                         </div>
                     </form>
                     <p className="mt-5 text-center">{errorMsg}</p>
@@ -57,6 +58,7 @@ const Login = () => {
                 <h2 className="mt-10 mb-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Welcome to the blog!</h2>
                 <div className="flex justify-center">
                     <button onClick={removeLoginCookie} className="flex justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Sign out</button>
+                    <button onClick={() => router.replace("/")} className="flex ml-4 justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Home</button>
                 </div>
             </>}
     </div>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,65 @@
+import { useCookies } from 'react-cookie'
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+
+const Login = () => {
+    const [cookies, setCookie, removeCookie] = useCookies(['user'])
+    const [userName, setUserName] = useState("")
+    const [password, setPassword] = useState("")
+    const [errorMsg, setErrorMsg] = useState("")
+    const router = useRouter()
+    const callbackURL = router.query.callbackURL?.toString() || "/"
+
+    const setLoginCookie = (event: React.FormEvent) => {
+        event.preventDefault()
+        if (userName === 'Admin' && password === "admin123") {
+            setErrorMsg("")
+            setCookie('user', userName, { path: '/' })
+            router.replace(callbackURL)
+        }
+        setErrorMsg("Invalid credentials!")
+    }
+
+    const removeLoginCookie = (event: React.MouseEvent) => {
+        event.preventDefault()
+        removeCookie('user')
+        router.replace(callbackURL)
+    }
+
+    return <div className="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+        {!cookies['user'] ?
+            <>
+                <div className="sm:mx-auto sm:w-full sm:max-w-sm">
+                    <h2 className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Sign in to your account</h2>
+                </div>
+                <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+                    <form id="loginForm" className="space-y-6" onSubmit={(event) => setLoginCookie(event)}>
+                        <div>
+                            <label htmlFor="email" className="block text-sm font-medium leading-6 text-gray-900">Username</label>
+                            <div className="mt-2">
+                                <input name="username" value={userName} type="text" onChange={e => setUserName(e.target.value)} required className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" />
+                            </div>
+                        </div>
+                        <div>
+                            <label htmlFor="password" className="block text-sm font-medium leading-6 text-gray-900">Password</label>
+                            <div className="mt-2">
+                                <input name="password" value={password} type="password" onChange={e => setPassword(e.target.value)} required className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" />
+                            </div>
+                        </div>
+                        <div>
+                            <button type="submit" className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Sign in</button>
+                        </div>
+                    </form>
+                    <p className="mt-5 text-center">{errorMsg}</p>
+                </div>
+            </>
+            : <>
+                <h2 className="mt-10 mb-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Welcome to the blog!</h2>
+                <div className="flex justify-center">
+                    <button onClick={removeLoginCookie} className="flex justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Sign out</button>
+                </div>
+            </>}
+    </div>
+}
+
+export default Login

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -27,7 +27,7 @@ const Post = ({ post, morePosts, preview }: Props) => {
     if (cookies['user'] === undefined && post.premium) {
       router.push({ pathname: "/login", query: { callbackURL: router.asPath } })
     }
-  })
+  }, [cookies])
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage statusCode={404} />
   }

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -11,6 +11,8 @@ import Head from 'next/head'
 import { CMS_NAME } from '../../lib/constants'
 import markdownToHtml from '../../lib/markdownToHtml'
 import PostType from '../../types/post'
+import { useCookies } from 'react-cookie'
+import { useEffect } from 'react'
 
 type Props = {
   post: PostType
@@ -20,13 +22,19 @@ type Props = {
 
 const Post = ({ post, morePosts, preview }: Props) => {
   const router = useRouter()
+  const [cookies] = useCookies(['user'])
+  useEffect(() => {
+    if (cookies['user'] === undefined && post.premium) {
+      router.push({ pathname: "/login", query: { callbackURL: router.asPath } })
+    }
+  })
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage statusCode={404} />
   }
   return (
     <Layout preview={preview}>
       <Container>
-        <Header />
+        <Header callbackURL={router.asPath} />
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>
         ) : (
@@ -43,6 +51,7 @@ const Post = ({ post, morePosts, preview }: Props) => {
                 coverImage={post.coverImage}
                 date={post.date}
                 author={post.author}
+                premium={post.premium}
               />
               <PostBody content={post.content} />
             </article>
@@ -70,6 +79,7 @@ export async function getStaticProps({ params }: Params) {
     'content',
     'ogImage',
     'coverImage',
+    'premium',
   ])
   const content = await markdownToHtml(post.content || '')
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   purge: ['./components/**/*.tsx', './pages/**/*.tsx'],
+  plugins: [
+    require('@tailwindcss/forms'),
+  ],
   theme: {
     extend: {
       colors: {

--- a/types/post.ts
+++ b/types/post.ts
@@ -11,6 +11,7 @@ type PostType = {
     url: string
   }
   content: string
+  premium: number
 }
 
 export default PostType


### PR DESCRIPTION
This PR is for the paywall changes that restrict access to premium content when users aren't logged in.

These are the changes:
1. Added 2 dependencies, i.e. react-cookie for reading and writing cookies, and tailwindcss/forms for the login page
2. Changed the structure of the Post object by adding a property 'premium', which is a number (0/1) to indicate whether the current page is premium content or not. 
3. Updated the header component to include the new loginheader component. Added the callbackURL prop to the header component to help redirect after login/logout.
4. Created a new loginheader component that displays the username of the logged in user (or 'Guest' if not logged in) which can be used to login/logout. This component reads the cookies to check if user has logged in and updates text accordingly.
5. Updated the _app.tsx to include the <CookiesProvider> tags to allow access to the react-cookie hooks throughout the app.
6. Updated the index.tsx page to include the loginheader component.
7.  Created a new login page that has a simple form with username and password fields, which are validated to display respective error messages (empty checks, invalid details). If user logs in successfully, the page displays a welcome message with a logout button
8. Updated the [slug].tsx page to check if user has logged in and if the post has premium content. If non-logged in users try to access the premium pages(either clicking on it or typing the url), it redirects them to the login page. Once logged in, it lands back in the appropriate premium page.