### PR TITLE
Add rudimentary paywall to blog.

### DIFF
--- a/_posts/dynamic-routing.md
+++ b/_posts/dynamic-routing.md
@@ -2,6 +2,7 @@
 title: 'Dynamic Routing and Static Generation'
 excerpt: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus.'
 coverImage: '/assets/blog/dynamic-routing/cover.jpg'
+level: 'basic'
 date: '2020-03-16T05:35:07.322Z'
 author:
   name: JJ Kasper

--- a/_posts/hello-world.md
+++ b/_posts/hello-world.md
@@ -2,6 +2,7 @@
 title: 'Learn How to Pre-render Pages Using Static Generation with Next.js'
 excerpt: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus.'
 coverImage: '/assets/blog/hello-world/cover.jpg'
+level: 'premium'
 date: '2020-03-16T05:35:07.322Z'
 author:
   name: Tim Neutkens

--- a/_posts/preview.md
+++ b/_posts/preview.md
@@ -2,6 +2,7 @@
 title: 'Preview Mode for Static Generation'
 excerpt: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus.'
 coverImage: '/assets/blog/preview/cover.jpg'
+level: 'basic'
 date: '2020-03-16T05:35:07.322Z'
 author:
   name: Joe Haddad

--- a/components/cover-image.tsx
+++ b/components/cover-image.tsx
@@ -5,9 +5,11 @@ type Props = {
   title: string
   src: string
   slug?: string
+  isAuthenticated?: string
 }
 
-const CoverImage = ({ title, src, slug }: Props) => {
+const CoverImage = ({ title, src, slug, isAuthenticated = 'false' }: Props) => {
+  const paywallPath = isAuthenticated == 'true' ? `/posts/${slug}` : `/paywall?post=${slug}`;
   const image = (
     <img
       src={src}
@@ -20,7 +22,7 @@ const CoverImage = ({ title, src, slug }: Props) => {
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link as={paywallPath} href={paywallPath}>
           <a aria-label={title}>{image}</a>
         </Link>
       ) : (

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -10,7 +10,8 @@ type Props = {
   date: string
   excerpt: string
   author: Author
-  slug: string
+  slug: string,
+  isAuthenticated: string,
 }
 
 const HeroPost = ({
@@ -20,16 +21,18 @@ const HeroPost = ({
   excerpt,
   author,
   slug,
+  isAuthenticated
 }: Props) => {
+  const paywallPath = isAuthenticated == 'true' ? `/posts/${slug}` : `/paywall?post=${slug}`;
   return (
     <section>
       <div className="mb-8 md:mb-16">
-        <CoverImage title={title} src={coverImage} slug={slug} />
+        <CoverImage title={title} src={coverImage} slug={slug} isAuthenticated={isAuthenticated}/>
       </div>
       <div className="md:grid md:grid-cols-2 md:gap-x-16 lg:gap-x-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link as={paywallPath} href={paywallPath}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -3,9 +3,10 @@ import Post from '../types/post'
 
 type Props = {
   posts: Post[]
+  isAuthenticated?: string
 }
 
-const MoreStories = ({ posts }: Props) => {
+const MoreStories = ({ posts, isAuthenticated }: Props) => {
   return (
     <section>
       <h2 className="mb-8 text-6xl md:text-7xl font-bold tracking-tighter leading-tight">
@@ -21,6 +22,8 @@ const MoreStories = ({ posts }: Props) => {
             author={post.author}
             slug={post.slug}
             excerpt={post.excerpt}
+            level={post.level}
+            isAuthenticated={isAuthenticated}
           />
         ))}
       </div>

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -11,6 +11,8 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  level: string
+  isAuthenticated?: string
 }
 
 const PostPreview = ({
@@ -20,15 +22,19 @@ const PostPreview = ({
   excerpt,
   author,
   slug,
+  level,
+  isAuthenticated
 }: Props) => {
+  const paywallPath = isAuthenticated == 'true' ? `/posts/${slug}` : `/paywall?post=${slug}`;
+  const isPremium = level == 'premium' ? true : false;
   return (
     <div>
       <div className="mb-5">
-        <CoverImage slug={slug} title={title} src={coverImage} />
+        <CoverImage slug={slug} title={title} src={coverImage} isAuthenticated={isAuthenticated}/>
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
-          <a className="hover:underline">{title}</a>
+        <Link as={paywallPath} href={paywallPath}>
+          <a className="hover:underline">{isPremium && 'Premium Content: '}{title}</a>
         </Link>
       </h3>
       <div className="text-lg mb-4">

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "date-fns": "2.21.3",
     "gray-matter": "4.0.3",
     "next": "latest",
+    "nookies": "^2.5.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remark": "13.0.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,12 +7,15 @@ import { getAllPosts } from '../lib/api'
 import Head from 'next/head'
 import { CMS_NAME } from '../lib/constants'
 import Post from '../types/post'
+import { parseCookies, setCookie, destroyCookie } from 'nookies'
 
 type Props = {
-  allPosts: Post[]
+  allPosts: Post[],
 }
 
-const Index = ({ allPosts }: Props) => {
+const Index = ({ allPosts}: Props) => {
+  const cookies = parseCookies()
+  const isAuthenticated = cookies['isAuthenticated'] || 'false';
   const heroPost = allPosts[0]
   const morePosts = allPosts.slice(1)
   return (
@@ -31,9 +34,10 @@ const Index = ({ allPosts }: Props) => {
               author={heroPost.author}
               slug={heroPost.slug}
               excerpt={heroPost.excerpt}
+              isAuthenticated={isAuthenticated}
             />
           )}
-          {morePosts.length > 0 && <MoreStories posts={morePosts} />}
+          {morePosts.length > 0 && <MoreStories posts={morePosts} isAuthenticated={isAuthenticated} />}
         </Container>
       </Layout>
     </>
@@ -50,6 +54,7 @@ export const getStaticProps = async () => {
     'author',
     'coverImage',
     'excerpt',
+    'level',
   ])
 
   return {

--- a/pages/paywall.tsx
+++ b/pages/paywall.tsx
@@ -1,0 +1,63 @@
+import Layout from '../components/layout';
+import Container from '../components/container';
+import Head from 'next/head'
+import { CMS_NAME } from '../lib/constants'
+import { useState } from 'react';
+import Router from 'next/router'
+import { setCookie} from 'nookies'
+
+export default function Paywall() {
+
+  const [inputs, setInputs] = useState({ username: '', password: '' });
+
+  const handleChange = (event: any) => {
+    const name = event.target.name;
+    const value = event.target.value;
+    setInputs(values => ({ ...values, [name]: value }));
+  }
+
+  const handleSubmit = async (e: any) => {
+    e.preventDefault();
+    if (inputs.username == 'u' && inputs.password == 'p') {
+      setCookie(null,'isAuthenticated', 'true');
+      const {post} = Router.query;
+      Router.push({
+        pathname: `/posts/${post}`,
+      })
+    }
+  }
+
+  return (
+    <>
+      <Layout>
+        <Head>
+          <title>Next.js Blog Example with {CMS_NAME}</title>
+        </Head>
+        <Container>
+          <form onSubmit={handleSubmit}>
+            <label htmlFor="title">Username:
+              <input
+                type="text"
+                name="username"
+                value={inputs.username || ''}
+                onChange={handleChange}
+              />
+            </label>
+            <label htmlFor="title">Password:
+              <input
+                type="text"
+                name="password"
+                value={inputs.password || ''}
+                onChange={handleChange}
+              />
+            </label>
+            <input
+              type="submit"
+              value="Login"
+            />
+          </form>
+        </Container>
+      </Layout>
+    </>
+  )
+}

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -11,6 +11,7 @@ import Head from 'next/head'
 import { CMS_NAME } from '../../lib/constants'
 import markdownToHtml from '../../lib/markdownToHtml'
 import PostType from '../../types/post'
+import { parseCookies, setCookie, destroyCookie } from 'nookies'
 
 type Props = {
   post: PostType
@@ -22,6 +23,12 @@ const Post = ({ post, morePosts, preview }: Props) => {
   const router = useRouter()
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage statusCode={404} />
+  } else {
+    const cookies = parseCookies()
+    const isAuthenticated = cookies['isAuthenticated'] || 'false';
+    if (!isAuthenticated) {
+      router.push('/paywall');
+    }
   }
   return (
     <Layout preview={preview}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -471,6 +471,11 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 cosmiconfig@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
@@ -1083,6 +1088,14 @@ node-releases@^2.0.6:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
   integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
 
+nookies@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/nookies/-/nookies-2.5.2.tgz#cc55547efa982d013a21475bd0db0c02c1b35b27"
+  integrity sha512-x0TRSaosAEonNKyCrShoUaJ5rrT5KHRNZ5DwPCuizjgrnkpE5DRf3VL7AyyQin4htict92X1EQ7ejDbaHDVdYA==
+  dependencies:
+    cookie "^0.4.1"
+    set-cookie-parser "^2.4.6"
+
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
@@ -1397,6 +1410,11 @@ section-matter@^1.0.0:
   dependencies:
     extend-shallow "^2.0.1"
     kind-of "^6.0.0"
+
+set-cookie-parser@^2.4.6:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz#131921e50f62ff1a66a461d7d62d7b21d5d15a51"
+  integrity sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==
 
 simple-swizzle@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
• I continued with what we worked on during the call. My impression was that it was important to pass authentication as a prop (for this exercise), rather than use session authentication (e.g. next-auth/react). A few notes:
• we had talked about index.ts using getServerSideProps but with Next's client-side navigation, you would have to deliberately make fetches to the server/getServerSideProps for the cookie. Instead, I reverted getServerSideProps back to getStaticProps and set a client-side cookie.
• Links, in both cover images and post titles, should have proper logic to redirect to a paywall if not authenticated.
• The post's slug is preserved, so that after authenticating at the paywall with username 'u' and password 'p', a user is redirected to the post they initially clicked. FYI, the login button works but the repo's styling prevents hover animation etc.
• Posts marked 'Premium' are prefixed with "Premium Content".