### PR TITLE
[Feature] Implement Premium Post Paywalls

### DIFF
--- a/_posts/dynamic-routing.md
+++ b/_posts/dynamic-routing.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/jj.jpeg'
 ogImage:
   url: '/assets/blog/dynamic-routing/cover.jpg'
+premium: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/hello-world.md
+++ b/_posts/hello-world.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/tim.jpeg'
 ogImage:
   url: '/assets/blog/hello-world/cover.jpg'
+premium: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/preview.md
+++ b/_posts/preview.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/joe.jpeg'
 ogImage:
   url: '/assets/blog/preview/cover.jpg'
+premium: false
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,13 +1,16 @@
 import Link from 'next/link'
+import Login from './login'
 
 const Header = () => {
   return (
-    <h2 className="text-2xl md:text-4xl font-bold tracking-tight md:tracking-tighter leading-tight mb-20 mt-8">
-      <Link href="/">
-        <a className="hover:underline">Blog</a>
-      </Link>
-      .
-    </h2>
+    <div className="flex justify-between items-center tracking-tight md:tracking-tighter leading-tight mb-20 mt-8">
+      <h2 className="text-2xl md:text-4xl font-bold">
+        <Link href="/">
+          <a className="hover:underline">Blog</a>
+        </Link>
+      </h2>
+      <Login/>
+    </div>
   )
 }
 

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -3,6 +3,7 @@ import DateFormatter from './date-formatter'
 import CoverImage from './cover-image'
 import Link from 'next/link'
 import Author from '../types/author'
+import PostPremiumFlag from './post-premium-flag'
 
 type Props = {
   title: string
@@ -11,6 +12,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  premium: boolean
 }
 
 const HeroPost = ({
@@ -20,6 +22,7 @@ const HeroPost = ({
   excerpt,
   author,
   slug,
+  premium,
 }: Props) => {
   return (
     <section>
@@ -33,6 +36,9 @@ const HeroPost = ({
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>
+          <div className="text-lg">
+            {premium && <PostPremiumFlag />}
+          </div>
           <div className="mb-4 md:mb-0 text-lg">
             <DateFormatter dateString={date} />
           </div>

--- a/components/intro.tsx
+++ b/components/intro.tsx
@@ -1,21 +1,12 @@
-import { CMS_NAME } from '../lib/constants'
+import Login from './login'
 
 const Intro = () => {
   return (
-    <section className="flex-col md:flex-row flex items-center md:justify-between mt-16 mb-16 md:mb-12">
-      <h1 className="text-6xl md:text-8xl font-bold tracking-tighter leading-tight md:pr-8">
+    <section className="flex-row flex items-center justify-between mt-16 mb-8">
+      <h1 className="text-6xl font-bold tracking-tighter leading-tight">
         Blog.
       </h1>
-      <h4 className="text-center md:text-left text-lg mt-5 md:pl-8">
-        A statically generated blog example using{' '}
-        <a
-          href="https://nextjs.org/"
-          className="underline hover:text-success duration-200 transition-colors"
-        >
-          Next.js
-        </a>{' '}
-        and {CMS_NAME}.
-      </h4>
+      <Login />
     </section>
   )
 }

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -1,0 +1,37 @@
+import LoginFormEvent from '../types/login-form-event'
+
+type Props = {
+  errorMessage?: string
+  onSubmit: (e: LoginFormEvent) => void
+}
+
+const LoginForm = ({ errorMessage, onSubmit }: Props) => {
+  return (
+    <div className="flex items-center justify-center w-full bg">
+      <form className="bg-gray-50 px-8 pt-6 pb-8" onSubmit={onSubmit} >
+        <div className="mb-4">
+          <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="username">
+            Username
+          </label>
+          <input className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="username" type="text" placeholder="Username" />
+        </div>
+        <div>
+          <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="password">
+            Password
+          </label>
+          <input className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="password" type="password" placeholder="Password" />
+        </div>
+        {errorMessage && (
+          <div>
+            <span className="text-red-700">{errorMessage}</span>
+          </div>
+        )}
+        <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline mt-6" type="submit">
+          Sign In
+        </button>
+      </form>
+    </div>
+  )
+}
+
+export default LoginForm

--- a/components/login-modal.tsx
+++ b/components/login-modal.tsx
@@ -1,17 +1,34 @@
+import { useState } from 'react'
 import LoginForm from './login-form'
 import LoginFormEvent from '../types/login-form-event'
+import { loginService } from '../utils/login-service'
 
 type Props = {
-  errorMessage?: string
-  onSubmit: (e: LoginFormEvent) => void
+  title: string
+  onLogin(): void
+  onClose?(): void
 }
 
-const LoginModal = ({ errorMessage, onSubmit }: Props) => {
+const LoginModal = ({ title, onLogin, onClose }: Props) => {
+  const [error, setError] = useState<string>()
+  const onSubmit = (e: LoginFormEvent) => {
+    e.preventDefault()
+    setError(undefined)
+
+    try {
+      loginService(e.target.username.value, e.target.password.value)
+      onLogin()
+    } catch (err) {
+      setError((err as Error).message)
+    }
+  }
+
   return (
-    <div className="flex h-screen w-screen justify-center items-center overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
-      <div className="flex flex-col items-center justify-center p-16 bg-gray-50 shadow appearance-none border rounded">
-        <h2 className="text-2xl">Sign in to view this premium article.</h2>
-        <LoginForm errorMessage={errorMessage} onSubmit={onSubmit}/>
+    <div className="flex flex-col h-screen w-screen justify-center items-center overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
+      <div className="flex flex-col items-center justify-center p-4 bg-gray-50 shadow appearance-none border rounded">
+        {onClose && (<div className="self-end p-2 cursor-pointer" onClick={onClose}>x</div>)}
+        <h2 className="text-2xl">{title}</h2>
+        <LoginForm errorMessage={error} onSubmit={onSubmit} />
       </div>
     </div>
   )

--- a/components/login-modal.tsx
+++ b/components/login-modal.tsx
@@ -1,0 +1,20 @@
+import LoginForm from './login-form'
+import LoginFormEvent from '../types/login-form-event'
+
+type Props = {
+  errorMessage?: string
+  onSubmit: (e: LoginFormEvent) => void
+}
+
+const LoginModal = ({ errorMessage, onSubmit }: Props) => {
+  return (
+    <div className="flex h-screen w-screen justify-center items-center overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
+      <div className="flex flex-col items-center justify-center p-16 bg-gray-50 shadow appearance-none border rounded">
+        <h2 className="text-2xl">Sign in to view this premium article.</h2>
+        <LoginForm errorMessage={errorMessage} onSubmit={onSubmit}/>
+      </div>
+    </div>
+  )
+}
+
+export default LoginModal

--- a/components/login.tsx
+++ b/components/login.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { deleteCookie } from 'cookies-next'
+import { authorizeService } from '../utils/authorize-service'
+import { SESSION_COOKIE_NAME } from '../lib/constants'
+import LoginModal from './login-modal'
+
+
+const Login = () => {
+  const router = useRouter()
+  const [modalVisible, setModalVisible] = useState(false)
+  const loggedIn = authorizeService()
+
+  const hideModal = () => setModalVisible(false)
+  const showModal = () => setModalVisible(true)
+  const logout = () => {
+    deleteCookie(SESSION_COOKIE_NAME)
+    router.reload()
+  }
+
+  if (loggedIn) {
+    return (
+      <div className="text-yellow-500 cursor-pointer">
+        <h3 onClick={logout}>Sign Out</h3>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="text-yellow-500 cursor-pointer">
+        <h3 onClick={showModal}>Sign In</h3>
+      </div>
+      {modalVisible && <LoginModal title="Sign In" onLogin={hideModal} onClose={hideModal} />}
+    </>
+  )
+}
+
+export default Login

--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -21,6 +21,7 @@ const MoreStories = ({ posts }: Props) => {
             author={post.author}
             slug={post.slug}
             excerpt={post.excerpt}
+            premium={post.premium}
           />
         ))}
       </div>

--- a/components/post-premium-flag.tsx
+++ b/components/post-premium-flag.tsx
@@ -1,0 +1,12 @@
+import PremiumLock from './premium-lock'
+
+const PostPremiumFlag = () => {
+  return (
+    <div className="inline-flex items-center space-x-2 text-lg text-yellow-500">
+      <div>Premium Post</div>
+      <PremiumLock />
+    </div>
+  )
+}
+
+export default PostPremiumFlag

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -3,6 +3,7 @@ import DateFormatter from './date-formatter'
 import CoverImage from './cover-image'
 import Link from 'next/link'
 import Author from '../types/author'
+import PostPremiumFlag from './post-premium-flag'
 
 type Props = {
   title: string
@@ -11,6 +12,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  premium: boolean
 }
 
 const PostPreview = ({
@@ -20,6 +22,7 @@ const PostPreview = ({
   excerpt,
   author,
   slug,
+  premium,
 }: Props) => {
   return (
     <div>
@@ -31,6 +34,9 @@ const PostPreview = ({
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>
+      <div className="text-lg">
+        {premium && <PostPremiumFlag />}
+      </div>
       <div className="text-lg mb-4">
         <DateFormatter dateString={date} />
       </div>

--- a/components/premium-lock.tsx
+++ b/components/premium-lock.tsx
@@ -1,0 +1,13 @@
+const PremiumLock = () => {
+  return (
+    <div>
+      <svg className="h-4 w-4 fill-current text-yellow-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+        <path d="M4 8V6a6 6 0 1 1 12 0v2h1a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-8c0-1.1.9-2 2-2h1zm5 6.73V17h2v-2.27a2 2 0 1 0-2 0zM7 6v2h6V6a3 3 0 0 0-6 0z" />
+      </svg>
+    </div>
+  )
+}
+
+export default PremiumLock
+
+

--- a/data/users.json
+++ b/data/users.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 1,
+    "username": "admin",
+    "password": "test",
+    "firstName": "Admin",
+    "lastName": "User"
+  }
+]

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -2,3 +2,4 @@ export const EXAMPLE_PATH = 'blog-starter-typescript'
 export const CMS_NAME = 'Markdown'
 export const HOME_OG_IMAGE_URL =
   'https://og-image.vercel.app/Next.js%20Blog%20Starter%20Example.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnextjs-black-logo.svg'
+export const SESSION_COOKIE_NAME = 'token'

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "classnames": "2.3.1",
+    "cookies-next": "^2.1.2",
     "date-fns": "2.21.3",
     "gray-matter": "4.0.3",
     "next": "latest",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,6 +50,7 @@ export const getStaticProps = async () => {
     'author',
     'coverImage',
     'excerpt',
+    'premium',
   ])
 
   return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,6 +31,7 @@ const Index = ({ allPosts }: Props) => {
               author={heroPost.author}
               slug={heroPost.slug}
               excerpt={heroPost.excerpt}
+              premium={heroPost.premium}
             />
           )}
           {morePosts.length > 0 && <MoreStories posts={morePosts} />}

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -70,6 +70,7 @@ export async function getStaticProps({ params }: Params) {
     'content',
     'ogImage',
     'coverImage',
+    'premium',
   ])
   const content = await markdownToHtml(post.content || '')
 

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -14,9 +14,7 @@ import { CMS_NAME } from '../../lib/constants'
 import markdownToHtml from '../../lib/markdownToHtml'
 import PostType from '../../types/post'
 import { authorizeService } from '../../utils/authorize-service'
-import LoginFormEvent from '../../types/login-form-event'
 import LoginModal from '../../components/login-modal'
-import { loginService } from '../../utils/login-service'
 
 type Props = {
   post: PostType
@@ -24,10 +22,11 @@ type Props = {
   preview?: boolean
 }
 
+const MODAL_TEXT = 'Sign in to view this premium article.'
+
 const Post = ({ post, morePosts, preview }: Props) => {
-  const [error, setError] = useState<string>()
   const router = useRouter()
-  const authorized = authorizeService() || !post.premium
+  const [authorized, setAuthorized] = useState<boolean>(authorizeService() || !post.premium)
 
   useEffect(() => {
     const body = document.querySelector("body")
@@ -36,15 +35,8 @@ const Post = ({ post, morePosts, preview }: Props) => {
     }
   }, [authorized])
 
-  const onSubmit = (e: LoginFormEvent) => {
-    e.preventDefault()
-    setError(undefined)
-
-    try {
-      loginService(e.target.username.value, e.target.password.value)
-    } catch (err) {
-      setError((err as Error).message)
-    }
+  const onLogin = () => {
+    setAuthorized(true)
   }
 
   if (!router.isFallback && !post?.slug) {
@@ -60,7 +52,7 @@ const Post = ({ post, morePosts, preview }: Props) => {
           <>
               <article className={cn('mb-32', {
                 'filter blur-sm': !authorized
-      })}>
+              })}>
               <Head>
                 <title>
                   {post.title} | Next.js Blog Example with {CMS_NAME}
@@ -77,7 +69,7 @@ const Post = ({ post, morePosts, preview }: Props) => {
             </article>
           </>
         )}
-        {!authorized && <LoginModal errorMessage={error} onSubmit={onSubmit} />}
+        {!authorized && <LoginModal title={MODAL_TEXT} onLogin={onLogin}/>}
       </Container>
     </Layout>
   )

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -35,6 +35,24 @@ const Post = ({ post, morePosts, preview }: Props) => {
     }
   }, [authorized])
 
+  // Ensures the user can scroll when navigating back on
+  // a premium post when a user is not logged in
+  useEffect(() => {
+    router.beforePopState(({ as }) => {
+      if (as !== router.asPath) {
+        const body = document.querySelector("body")
+        if (body) {
+          body.style.overflow = "auto"
+        }
+      }
+      return true
+    })
+
+    return () => {
+      router.beforePopState(() => true)
+    }
+  }, [router])
+
   const onLogin = () => {
     setAuthorized(true)
   }

--- a/types/login-error.ts
+++ b/types/login-error.ts
@@ -1,0 +1,6 @@
+type LoginError = {
+  status: number
+  message: string
+}
+
+export default LoginError

--- a/types/login-form-event.ts
+++ b/types/login-form-event.ts
@@ -1,0 +1,12 @@
+import { FormEvent } from "react"
+
+type LoginFormAttributes = {
+  username: { value: string }
+  password: { value: string }
+}
+
+type LoginFormEvent = FormEvent<HTMLFormElement> & {
+  target: EventTarget & LoginFormAttributes
+}
+
+export default LoginFormEvent

--- a/types/post.ts
+++ b/types/post.ts
@@ -11,6 +11,7 @@ type PostType = {
     url: string
   }
   content: string
+  premium: boolean
 }
 
 export default PostType

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,0 +1,9 @@
+type User = {
+  id: number
+  username: string
+  password: string
+  firstName: string
+  lastName: string
+}
+
+export default User

--- a/utils/authorize-service.ts
+++ b/utils/authorize-service.ts
@@ -1,0 +1,7 @@
+import { getCookie } from 'cookies-next'
+import { SESSION_COOKIE_NAME } from '../lib/constants'
+
+export const authorizeService = () => {
+  const cookie = getCookie(SESSION_COOKIE_NAME)
+  return cookie !== undefined
+}

--- a/utils/login-service.ts
+++ b/utils/login-service.ts
@@ -1,0 +1,14 @@
+import { setCookie } from 'cookies-next'
+
+import User from '../types/user'
+import { SESSION_COOKIE_NAME } from '../lib/constants'
+
+export const loginService = (username: string, password: string) => {
+  const users: User[] = require('data/users.json')
+  const user = users.find(user => user.username === username && user.password === password)
+  if (user) {
+    setCookie(SESSION_COOKIE_NAME, user.username)
+  } else {
+    throw new Error("Username and password not found")
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,6 +132,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -175,6 +180,11 @@
   version "15.14.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.9.tgz#bc43c990c3c9be7281868bbc7b8fdd6e2b57adfa"
   integrity sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==
+
+"@types/node@^16.10.2":
+  version "16.18.39"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.39.tgz#aa39a1a87a40ef6098ee69689a1acb0c1b034832"
+  integrity sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -470,6 +480,20 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+cookie@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
+cookies-next@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookies-next/-/cookies-next-2.1.2.tgz#78fe2f3e7b68eb0e1c6682c9e1f4e94ce4d09904"
+  integrity sha512-czxcfqVaQlo0Q/3xMgp/2jpspsuLJrIm6D37wlmibP3DAcYT315c8UxQmDMohhAT/GRWpaHzpDEFANBjzTFQGg==
+  dependencies:
+    "@types/cookie" "^0.4.1"
+    "@types/node" "^16.10.2"
+    cookie "^0.4.0"
 
 cosmiconfig@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
## Context
Previously, all posts were available to the public. We need to implement a paywall for new "premium" posts. Users of the website should not be able to see post details unless they're logged in.

## Changes
- Add `premium` metadata to posts
- Add premium article indicator to post previews
- Add login modal pop-up and blurring functionality
- Implement login/logout in blog header

Hardcoded credentials for local sign in
username: admin
password: test