### PR TITLE
Add paywall feature

### DIFF
--- a/_posts/dynamic-routing.md
+++ b/_posts/dynamic-routing.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/jj.jpeg'
 ogImage:
   url: '/assets/blog/dynamic-routing/cover.jpg'
+premium: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/preview.md
+++ b/_posts/preview.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/joe.jpeg'
 ogImage:
   url: '/assets/blog/preview/cover.jpg'
+premium: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/components/alert.tsx
+++ b/components/alert.tsx
@@ -1,44 +1,23 @@
 import Container from './container'
 import cn from 'classnames'
 import { EXAMPLE_PATH } from '../lib/constants'
+import { useLoggedInContext } from './authContext'
 
-type Props = {
-  preview?: boolean
-}
-
-const Alert = ({ preview }: Props) => {
+const Alert = () => {
+  const { isLoggedIn, toggleLoggedIn} = useLoggedInContext();
   return (
     <div
-      className={cn('border-b', {
-        'bg-accent-7 border-accent-7 text-white': preview,
-        'bg-accent-1 border-accent-2': !preview,
-      })}
+      className={cn('border-b', 'bg-accent-1 border-accent-2')}
     >
       <Container>
         <div className="py-2 text-center text-sm">
-          {preview ? (
-            <>
-              This page is a preview.{' '}
-              <a
-                href="/api/exit-preview"
-                className="underline hover:text-cyan duration-200 transition-colors"
-              >
-                Click here
-              </a>{' '}
-              to exit preview mode.
-            </>
-          ) : (
-            <>
-              The source code for this blog is{' '}
-              <a
-                href={`https://github.com/vercel/next.js/tree/canary/examples/${EXAMPLE_PATH}`}
-                className="underline hover:text-success duration-200 transition-colors"
-              >
-                available on GitHub
-              </a>
-              .
-            </>
-          )}
+          <span className='mr-2'>{!isLoggedIn && 'Not'} Logged In</span>
+          <button 
+            className='bg-blue-500 hover:bg-blue-700 text-white py-1 px-2 rounded' 
+            onClick={toggleLoggedIn}
+          >
+            Click Here to Log In
+          </button> 
         </div>
       </Container>
     </div>

--- a/components/alert.tsx
+++ b/components/alert.tsx
@@ -16,7 +16,7 @@ const Alert = () => {
             className='bg-blue-500 hover:bg-blue-700 text-white py-1 px-2 rounded' 
             onClick={toggleLoggedIn}
           >
-            Click Here to Log In
+            Toggle Log In
           </button> 
         </div>
       </Container>

--- a/components/authContext.tsx
+++ b/components/authContext.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext, useState } from 'react';
+
+const LoggedInContext = createContext({ isLoggedIn: false, toggleLoggedIn: () => {}});
+
+export function useLoggedInContext() {
+  return useContext(LoggedInContext);
+}
+
+
+type Props = {
+  children: React.ReactNode
+}
+
+export function AuthContext({ children }: Props) {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const toggleLoggedIn = () => setIsLoggedIn(l => !l);
+  return <LoggedInContext.Provider value={{ isLoggedIn, toggleLoggedIn }}>
+    {children}
+  </LoggedInContext.Provider>
+}

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -11,6 +11,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  premium?: boolean
 }
 
 const HeroPost = ({
@@ -20,6 +21,7 @@ const HeroPost = ({
   excerpt,
   author,
   slug,
+  premium,
 }: Props) => {
   return (
     <section>
@@ -33,6 +35,7 @@ const HeroPost = ({
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>
+          { premium && <h6 className='mb-4'>PREMIUM</h6>}
           <div className="mb-4 md:mb-0 text-lg">
             <DateFormatter dateString={date} />
           </div>

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,4 +1,5 @@
 import Alert from './alert'
+import { AuthContext } from './authContext'
 import Footer from './footer'
 import Meta from './meta'
 
@@ -9,14 +10,14 @@ type Props = {
 
 const Layout = ({ preview, children }: Props) => {
   return (
-    <>
+    <AuthContext>
       <Meta />
       <div className="min-h-screen">
-        <Alert preview={preview} />
+        <Alert />
         <main>{children}</main>
       </div>
       <Footer />
-    </>
+    </AuthContext>
   )
 }
 

--- a/components/login-prompt.tsx
+++ b/components/login-prompt.tsx
@@ -1,0 +1,9 @@
+const LoginPrompt = () => {
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h3>This is a premium article. Please Log In or create an account to view it.</h3>
+    </div>
+  )
+}
+
+export default LoginPrompt

--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -21,6 +21,7 @@ const MoreStories = ({ posts }: Props) => {
             author={post.author}
             slug={post.slug}
             excerpt={post.excerpt}
+            premium={post.premium}
           />
         ))}
       </div>

--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -1,16 +1,24 @@
+import { useLoggedInContext } from './authContext'
+import LoginPrompt from './login-prompt'
 import markdownStyles from './markdown-styles.module.css'
 
 type Props = {
   content: string
+  premium?: boolean
 }
 
-const PostBody = ({ content }: Props) => {
+const PostBody = ({ content, premium }: Props) => {
+    const { isLoggedIn } = useLoggedInContext();
+
   return (
     <div className="max-w-2xl mx-auto">
-      <div
-        className={markdownStyles['markdown']}
-        dangerouslySetInnerHTML={{ __html: content }}
-      />
+      {(premium && !isLoggedIn) 
+        ? <LoginPrompt /> 
+        : (<div
+            className={markdownStyles['markdown']}
+            dangerouslySetInnerHTML={{ __html: content }}
+          />)
+      }
     </div>
   )
 }

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -11,6 +11,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  premium?: boolean
 }
 
 const PostPreview = ({
@@ -20,6 +21,7 @@ const PostPreview = ({
   excerpt,
   author,
   slug,
+  premium,
 }: Props) => {
   return (
     <div>
@@ -31,6 +33,7 @@ const PostPreview = ({
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>
+      { premium && <h6 className='mb-4'>PREMIUM</h6>}
       <div className="text-lg mb-4">
         <DateFormatter dateString={date} />
       </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,6 +31,7 @@ const Index = ({ allPosts }: Props) => {
               author={heroPost.author}
               slug={heroPost.slug}
               excerpt={heroPost.excerpt}
+              premium={heroPost.premium}
             />
           )}
           {morePosts.length > 0 && <MoreStories posts={morePosts} />}
@@ -50,6 +51,7 @@ export const getStaticProps = async () => {
     'author',
     'coverImage',
     'excerpt',
+    'premium',
   ])
 
   return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,28 +16,26 @@ const Index = ({ allPosts }: Props) => {
   const heroPost = allPosts[0]
   const morePosts = allPosts.slice(1)
   return (
-    <>
-      <Layout>
-        <Head>
-          <title>Next.js Blog Example with {CMS_NAME}</title>
-        </Head>
-        <Container>
-          <Intro />
-          {heroPost && (
-            <HeroPost
-              title={heroPost.title}
-              coverImage={heroPost.coverImage}
-              date={heroPost.date}
-              author={heroPost.author}
-              slug={heroPost.slug}
-              excerpt={heroPost.excerpt}
-              premium={heroPost.premium}
-            />
-          )}
-          {morePosts.length > 0 && <MoreStories posts={morePosts} />}
-        </Container>
-      </Layout>
-    </>
+    <Layout>
+      <Head>
+        <title>Next.js Blog Example with {CMS_NAME}</title>
+      </Head>
+      <Container>
+        <Intro />
+        {heroPost && (
+          <HeroPost
+            title={heroPost.title}
+            coverImage={heroPost.coverImage}
+            date={heroPost.date}
+            author={heroPost.author}
+            slug={heroPost.slug}
+            excerpt={heroPost.excerpt}
+            premium={heroPost.premium}
+          />
+        )}
+        {morePosts.length > 0 && <MoreStories posts={morePosts} />}
+      </Container>
+    </Layout>
   )
 }
 

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -44,7 +44,7 @@ const Post = ({ post, morePosts, preview }: Props) => {
                 date={post.date}
                 author={post.author}
               />
-              <PostBody content={post.content} />
+              <PostBody content={post.content} premium={post.premium} />
             </article>
           </>
         )}
@@ -70,6 +70,7 @@ export async function getStaticProps({ params }: Params) {
     'content',
     'ogImage',
     'coverImage',
+    'premium',
   ])
   const content = await markdownToHtml(post.content || '')
 

--- a/types/post.ts
+++ b/types/post.ts
@@ -7,6 +7,7 @@ type PostType = {
   coverImage: string
   author: Author
   excerpt: string
+  premium?: boolean
   ogImage: {
     url: string
   }


### PR DESCRIPTION
Adds dummy login state in context to provide an example of a paywall feature. The context is available at the root of each page, but routing between pages resets the `loggedIn` state. A future pull request could persist the logged in state with the browser using cookies, httpOnly headers, or local storage, depending on the auth needs.