### PR TITLE
adding paywall and dummy login to next blog template

### DIFF
--- a/_posts/dynamic-routing.md
+++ b/_posts/dynamic-routing.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/jj.jpeg'
 ogImage:
   url: '/assets/blog/dynamic-routing/cover.jpg'
+isPremium: 'True' 
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/dynamic-routing.md
+++ b/_posts/dynamic-routing.md
@@ -8,7 +8,7 @@ author:
   picture: '/assets/blog/authors/jj.jpeg'
 ogImage:
   url: '/assets/blog/dynamic-routing/cover.jpg'
-isPremium: 'True' 
+isPremium: true 
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/hello-world.md
+++ b/_posts/hello-world.md
@@ -8,7 +8,7 @@ author:
   picture: '/assets/blog/authors/tim.jpeg'
 ogImage:
   url: '/assets/blog/hello-world/cover.jpg'
-isPremium: 'False'
+isPremium: false
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/hello-world.md
+++ b/_posts/hello-world.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/tim.jpeg'
 ogImage:
   url: '/assets/blog/hello-world/cover.jpg'
+isPremium: 'False'
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/preview.md
+++ b/_posts/preview.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/joe.jpeg'
 ogImage:
   url: '/assets/blog/preview/cover.jpg'
+isPremium: 'True'
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/preview.md
+++ b/_posts/preview.md
@@ -8,7 +8,7 @@ author:
   picture: '/assets/blog/authors/joe.jpeg'
 ogImage:
   url: '/assets/blog/preview/cover.jpg'
-isPremium: 'True'
+isPremium: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/components/auth-button-group.tsx
+++ b/components/auth-button-group.tsx
@@ -1,0 +1,36 @@
+import ModalWrapper from "./modal-wrapper";
+import SignInModal from "./sign-in";
+
+type AuthButtonGroupProps = {
+    showSignInModal: boolean;
+    showSignInButton: boolean;
+    toggleSignInModal: () => void;
+    handleSuccessfulSignIn: () => void;
+    handleSignOut: () => void;
+};
+
+const AuthButtonGroup: React.FC<AuthButtonGroupProps> = ({
+                                                             showSignInModal,
+                                                             showSignInButton,
+                                                             toggleSignInModal,
+                                                             handleSuccessfulSignIn,
+                                                             handleSignOut,
+                                                         }) => {
+    return (
+        <>
+            {showSignInButton ? (
+                <button id="sign-in-button" className="px-4 py-2 text-xl font-semibold rounded" onClick={toggleSignInModal}>Sign In</button>
+            ) : (
+                <button id="sign-out-button" className="px-4 py-2 text-xl font-semibold rounded" onClick={handleSignOut}>Sign Out</button>
+            )}
+
+            {showSignInModal &&
+                <ModalWrapper>
+                    <SignInModal onSuccessfulSignIn={handleSuccessfulSignIn} />
+                </ModalWrapper>
+            }
+        </>
+    );
+};
+
+export default AuthButtonGroup;

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,13 +1,53 @@
 import Link from 'next/link'
+import SignInModal from "./sign-in";
+import ModalWrapper from "./modal-wrapper";
+import {useEffect, useState} from "react";
 
-const Header = () => {
+type Props = {
+    signedIn: boolean
+}
+const Header = ({ signedIn }: Props) => {
+    const [showSignInModal, setShowSignInModal] = useState(false);
+    const [showSignInButton, setShowSignInButton] = useState(true);
+
+    useEffect(() => {
+        const isUserSignedIn = document.cookie.indexOf('username=admin') >= 0;
+        setShowSignInButton(!isUserSignedIn);
+    }, [signedIn]);
+
+    const toggleSignInModal = () => {
+        setShowSignInModal(!showSignInModal);
+    };
+
+    const handleSuccessfulSignIn = () => {
+        setShowSignInButton(false);
+        setShowSignInModal(false);
+    };
+
+    const handleSignOut = () => {
+        document.cookie = "username=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+        setShowSignInButton(true);
+    };
   return (
-    <h2 className="text-2xl md:text-4xl font-bold tracking-tight md:tracking-tighter leading-tight mb-20 mt-8">
-      <Link href="/">
-        <a className="hover:underline">Blog</a>
-      </Link>
-      .
-    </h2>
+      <div className="flex justify-between items-center">
+          <h2 className="text-2xl md:text-4xl font-bold tracking-tight md:tracking-tighter leading-tight mb-20 mt-8">
+              <Link href="/">
+                  <a className="hover:underline">Blog</a>
+              </Link>
+              .
+          </h2>
+          {showSignInButton ? (
+              <button id="sign-in-button" className="px-4 py-2 text-xl font-semibold rounded" onClick={toggleSignInModal}>Sign In</button>
+          ) : (
+              <button id="sign-out-button" className="px-4 py-2 text-xl font-semibold rounded" onClick={handleSignOut}>Sign Out</button>
+          )}
+
+          {showSignInModal &&
+              <ModalWrapper>
+                  <SignInModal onSuccessfulSignIn={handleSuccessfulSignIn} />
+              </ModalWrapper>
+          }
+      </div>
   )
 }
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link'
-import SignInModal from "./sign-in";
-import ModalWrapper from "./modal-wrapper";
 import {useEffect, useState} from "react";
+import AuthButtonGroup from "./auth-button-group";
 
 type Props = {
     signedIn: boolean
@@ -36,17 +35,13 @@ const Header = ({ signedIn }: Props) => {
               </Link>
               .
           </h2>
-          {showSignInButton ? (
-              <button id="sign-in-button" className="px-4 py-2 text-xl font-semibold rounded" onClick={toggleSignInModal}>Sign In</button>
-          ) : (
-              <button id="sign-out-button" className="px-4 py-2 text-xl font-semibold rounded" onClick={handleSignOut}>Sign Out</button>
-          )}
-
-          {showSignInModal &&
-              <ModalWrapper>
-                  <SignInModal onSuccessfulSignIn={handleSuccessfulSignIn} />
-              </ModalWrapper>
-          }
+          <AuthButtonGroup
+              showSignInModal={showSignInModal}
+              showSignInButton={showSignInButton}
+              toggleSignInModal={toggleSignInModal}
+              handleSuccessfulSignIn={handleSuccessfulSignIn}
+              handleSignOut={handleSignOut}
+          />
       </div>
   )
 }

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -10,7 +10,7 @@ type Props = {
   date: string
   excerpt: string
   author: Author
-  isPremium: string
+  isPremium: boolean
   slug: string
 }
 
@@ -34,7 +34,7 @@ const HeroPost = ({
             <Link as={`/posts/${slug}`} href="/posts/[slug]">
               <a className="hover:underline">{title}</a>
             </Link>
-            { isPremium == 'True' &&
+            { isPremium &&
                 <div>
                   <span style={{color: 'goldenrod'}}>
                     <i className="fa fa-star"></i> Premium Article

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -10,6 +10,7 @@ type Props = {
   date: string
   excerpt: string
   author: Author
+  isPremium: string
   slug: string
 }
 
@@ -20,6 +21,7 @@ const HeroPost = ({
   excerpt,
   author,
   slug,
+  isPremium
 }: Props) => {
   return (
     <section>
@@ -32,6 +34,13 @@ const HeroPost = ({
             <Link as={`/posts/${slug}`} href="/posts/[slug]">
               <a className="hover:underline">{title}</a>
             </Link>
+            { isPremium == 'True' &&
+                <div>
+                  <span style={{color: 'goldenrod'}}>
+                    <i className="fa fa-star"></i> Premium Article
+                  </span>
+                </div>
+            }
           </h3>
           <div className="mb-4 md:mb-0 text-lg">
             <DateFormatter dateString={date} />

--- a/components/intro.tsx
+++ b/components/intro.tsx
@@ -1,23 +1,57 @@
-import { CMS_NAME } from '../lib/constants'
+import {CMS_NAME} from "../lib/constants";
+import SignInModal from "./sign-in";
+import ModalWrapper from "./modal-wrapper";
+import {useEffect, useState} from "react";
 
 const Intro = () => {
-  return (
-    <section className="flex-col md:flex-row flex items-center md:justify-between mt-16 mb-16 md:mb-12">
-      <h1 className="text-6xl md:text-8xl font-bold tracking-tighter leading-tight md:pr-8">
-        Blog.
-      </h1>
-      <h4 className="text-center md:text-left text-lg mt-5 md:pl-8">
-        A statically generated blog example using{' '}
-        <a
-          href="https://nextjs.org/"
-          className="underline hover:text-success duration-200 transition-colors"
-        >
-          Next.js
-        </a>{' '}
-        and {CMS_NAME}.
-      </h4>
-    </section>
-  )
-}
+    const [showSignInModal, setShowSignInModal] = useState(false);
+    const [showSignInButton, setShowSignInButton] = useState(true);
 
-export default Intro
+    useEffect(() => {
+        const isUserSignedIn = document.cookie.indexOf('username=admin') >= 0;
+        setShowSignInButton(!isUserSignedIn);
+    }, [showSignInButton]);
+
+    const toggleSignInModal = () => {
+        setShowSignInModal(!showSignInModal);
+    };
+
+    const handleSuccessfulSignIn = () => {
+        setShowSignInButton(false);
+        setShowSignInModal(false);
+    };
+
+    const handleSignOut = () => {
+        document.cookie = "username=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+        setShowSignInButton(true);
+    };
+    return (
+        <section className="flex-col md:flex-row flex items-center md:justify-between mt-16 mb-16 md:mb-12">
+            <h1 className="text-6xl md:text-8xl font-bold tracking-tighter leading-tight md:pr-8">
+                Blog.
+            </h1>
+            {showSignInButton ? (
+                <button className="px-4 py-2 text-xl font-semibold rounded" onClick={toggleSignInModal}>Sign In</button>
+            ) : (
+                <button className="px-4 py-2 text-xl font-semibold rounded" onClick={handleSignOut}>Sign Out</button>
+            )}
+            {showSignInModal &&
+                <ModalWrapper>
+                    <SignInModal onSuccessfulSignIn={handleSuccessfulSignIn} />
+                </ModalWrapper>
+            }
+            <h4 className="text-center md:text-left text-lg mt-5 md:pl-8">
+                A statically generated blog example using{' '}
+                <a
+                    href="https://nextjs.org/"
+                    className="underline hover:text-success duration-200 transition-colors"
+                >
+                    Next.js
+                </a>{' '}
+                and {CMS_NAME}.
+            </h4>
+        </section>
+    );
+};
+
+export default Intro;

--- a/components/intro.tsx
+++ b/components/intro.tsx
@@ -1,7 +1,6 @@
 import {CMS_NAME} from "../lib/constants";
-import SignInModal from "./sign-in";
-import ModalWrapper from "./modal-wrapper";
 import {useEffect, useState} from "react";
+import AuthButtonGroup from "./auth-button-group";
 
 const Intro = () => {
     const [showSignInModal, setShowSignInModal] = useState(false);
@@ -30,16 +29,13 @@ const Intro = () => {
             <h1 className="text-6xl md:text-8xl font-bold tracking-tighter leading-tight md:pr-8">
                 Blog.
             </h1>
-            {showSignInButton ? (
-                <button className="px-4 py-2 text-xl font-semibold rounded" onClick={toggleSignInModal}>Sign In</button>
-            ) : (
-                <button className="px-4 py-2 text-xl font-semibold rounded" onClick={handleSignOut}>Sign Out</button>
-            )}
-            {showSignInModal &&
-                <ModalWrapper>
-                    <SignInModal onSuccessfulSignIn={handleSuccessfulSignIn} />
-                </ModalWrapper>
-            }
+            <AuthButtonGroup
+                showSignInModal={showSignInModal}
+                showSignInButton={showSignInButton}
+                toggleSignInModal={toggleSignInModal}
+                handleSuccessfulSignIn={handleSuccessfulSignIn}
+                handleSignOut={handleSignOut}
+            />
             <h4 className="text-center md:text-left text-lg mt-5 md:pl-8">
                 A statically generated blog example using{' '}
                 <a

--- a/components/modal-wrapper.tsx
+++ b/components/modal-wrapper.tsx
@@ -1,0 +1,15 @@
+const ModalWrapper: React.FC = ({ children }) => {
+    const modalWrapperStyles: React.CSSProperties = {
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        zIndex: 1000,
+        transition: 'opacity 0.4s ease-in-out, visibility 0.4s',
+        boxShadow: '0px 4px 6px rgba(0, 0, 0, 0.1), 0px 1px 3px rgba(0, 0, 0, 0.8)' // Softened shadows
+    };
+
+    return <div style={modalWrapperStyles}>{children}</div>;
+};
+
+export default ModalWrapper

--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -21,6 +21,7 @@ const MoreStories = ({ posts }: Props) => {
             author={post.author}
             slug={post.slug}
             excerpt={post.excerpt}
+            isPremium={post.isPremium}
           />
         ))}
       </div>

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -11,7 +11,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
-  isPremium: string
+  isPremium: boolean
 }
 
 const PostPreview = ({
@@ -32,7 +32,7 @@ const PostPreview = ({
         <Link as={`/posts/${slug}`} href="/posts/[slug]">
           <a className="hover:underline">{title}</a>
         </Link>
-          { isPremium == 'True' &&
+          { isPremium &&
               <div>
                   <span style={{color: 'goldenrod'}}>
                     <i className="fa fa-star"></i> Premium Article

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -11,10 +11,12 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  isPremium: string
 }
 
 const PostPreview = ({
   title,
+  isPremium,
   coverImage,
   date,
   excerpt,
@@ -30,6 +32,13 @@ const PostPreview = ({
         <Link as={`/posts/${slug}`} href="/posts/[slug]">
           <a className="hover:underline">{title}</a>
         </Link>
+          { isPremium == 'True' &&
+              <div>
+                  <span style={{color: 'goldenrod'}}>
+                    <i className="fa fa-star"></i> Premium Article
+                  </span>
+              </div>
+          }
       </h3>
       <div className="text-lg mb-4">
         <DateFormatter dateString={date} />

--- a/components/sign-in.tsx
+++ b/components/sign-in.tsx
@@ -1,0 +1,68 @@
+import {FC, FormEvent, useState} from "react";
+
+type SignInModalProps = {
+    onSuccessfulSignIn: () => void;
+}
+
+const SignInModal: FC<SignInModalProps> = ({ onSuccessfulSignIn }) => {
+    const [username, setUsername] = useState('');
+    const [password, setPassword] = useState('');
+
+    const handleSignIn = (event: FormEvent) => {
+        event.preventDefault();
+        if (username === 'admin' && password === 'admin') {
+            document.cookie = `username=${username}; path=/`;
+            onSuccessfulSignIn();
+        }
+    };
+
+    const commonStyles = {
+        fontSize: '24px',
+        padding: '15px',
+        borderRadius: '12px',
+        boxShadow: '0px 4px 6px rgba(0, 0, 0, 0.1), 0px 1px 3px rgba(0, 0, 0, 0.1)', // Softened shadows
+        transition: '0.3s',
+    };
+
+    const buttonStyles = {
+        ...commonStyles,
+        backgroundColor: '#007BFF',
+        color: 'white',
+        cursor: 'pointer',
+        '&:hover': {
+            backgroundColor: '#0056b3',
+        },
+    };
+
+    return (
+        <div style={{
+            backgroundColor: '#F8F9FA',
+            padding: '40px',
+            borderRadius: '20px',
+            width: '800px',
+            textAlign: 'center',
+            fontSize: '48px',
+            boxShadow: '0px 8px 16px 0px rgba(0,0,0,0.2)',
+        }} id="sign-in-modal">
+            <h2 style={{ color: '#343A40' }}>Sign In</h2>
+            <form onSubmit={handleSignIn} style={{
+                display: 'grid',
+                gap: '2rem',
+                textAlign: 'left'
+            }}>
+                <label style={{ fontSize: '24px', color: '#343A40' }}>
+                    Username:
+                    <input type="text" value={username} onChange={(e) => setUsername(e.target.value)} style={commonStyles} />
+                </label>
+                <label style={{ fontSize: '24px', color: '#343A40' }}>
+                    Password:
+                    <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} style={commonStyles} />
+                </label>
+                <button type="submit" style={buttonStyles}>Submit</button>
+            </form>
+        </div>
+    );
+
+};
+
+export default SignInModal;

--- a/hooks/useAuthHandler.tsx
+++ b/hooks/useAuthHandler.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+const useAuthHandlers = () => {
+    const [showSignInModal, setShowSignInModal] = useState(false);
+    const [showSignInButton, setShowSignInButton] = useState(true);
+
+    const toggleSignInModal = () => {
+        setShowSignInModal(!showSignInModal);
+    };
+
+    const handleSuccessfulSignIn = () => {
+        setShowSignInButton(false);
+        setShowSignInModal(false);
+    };
+
+    const handleSignOut = () => {
+        document.cookie = "username=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+        setShowSignInButton(true);
+    };
+
+    return {
+        showSignInModal,
+        showSignInButton,
+        toggleSignInModal,
+        handleSuccessfulSignIn,
+        handleSignOut,
+        setShowSignInButton // in case you want to manually set this from the component
+    };
+};
+
+export default useAuthHandlers;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,6 +31,7 @@ const Index = ({ allPosts }: Props) => {
               author={heroPost.author}
               slug={heroPost.slug}
               excerpt={heroPost.excerpt}
+              isPremium={heroPost.isPremium}
             />
           )}
           {morePosts.length > 0 && <MoreStories posts={morePosts} />}
@@ -50,6 +51,7 @@ export const getStaticProps = async () => {
     'author',
     'coverImage',
     'excerpt',
+    'isPremium'
   ])
 
   return {

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -11,6 +11,8 @@ import Head from 'next/head'
 import { CMS_NAME } from '../../lib/constants'
 import markdownToHtml from '../../lib/markdownToHtml'
 import PostType from '../../types/post'
+import {useEffect, useRef, useState} from "react";
+import SignInModal from "../../components/sign-in";
 
 type Props = {
   post: PostType
@@ -23,32 +25,94 @@ const Post = ({ post, morePosts, preview }: Props) => {
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage statusCode={404} />
   }
+  const blurContainerRef = useRef<HTMLDivElement>(null);
+  const [showSignInModal, setShowSignInModal] = useState(false);
+  const [isSignedIn, setIsSignedIn] = useState(false);
+
+  useEffect(() => {
+    const isUserSignedIn = document.cookie.indexOf('username=admin') >= 0;
+    if (post.isPremium === 'True' && !isUserSignedIn) {
+      const paywallElement = document.getElementById("paywall");
+      if (paywallElement) {
+        paywallElement.style.display = "flex";
+      }
+      if (blurContainerRef.current) {
+        blurContainerRef.current.style.filter = "blur(8px)";
+      }
+    }
+  }, [post.isPremium]);
+
+  const toggleSignInModal = () => {
+    setShowSignInModal(!showSignInModal);
+  };
+
+  const handleSuccessfulSignIn = () => {
+    setIsSignedIn(true);
+    if (blurContainerRef.current) {
+      blurContainerRef.current.style.filter = "none";
+    }
+    const paywallElement = document.getElementById("paywall");
+    if (paywallElement) {
+      paywallElement.style.display = "none";
+    }
+  };
   return (
     <Layout preview={preview}>
-      <Container>
-        <Header />
-        {router.isFallback ? (
-          <PostTitle>Loading…</PostTitle>
-        ) : (
-          <>
-            <article className="mb-32">
-              <Head>
-                <title>
-                  {post.title} | Next.js Blog Example with {CMS_NAME}
-                </title>
-                <meta property="og:image" content={post.ogImage.url} />
-              </Head>
-              <PostHeader
-                title={post.title}
-                coverImage={post.coverImage}
-                date={post.date}
-                author={post.author}
-              />
-              <PostBody content={post.content} />
-            </article>
-          </>
-        )}
-      </Container>
+        <div id="paywall" style={{display: 'none', position: 'fixed', top: 0, left: 0, width: '100%', height: '100%', backgroundColor: 'rgba(0,0,0,0.8)', zIndex: 9999, justifyContent: 'center', alignItems: 'center'}}>
+          {!showSignInModal ? (
+              <div style={{
+                backgroundColor: 'white',
+                padding: '20px',
+                borderRadius: '8px',
+                width: '600px',
+                textAlign: 'center',
+                fontSize: '36px'
+              }}>
+                <h2>Unlock Premium Content</h2>
+                <button
+                    onClick={toggleSignInModal}
+                    style={{
+                      backgroundColor: 'transparent',
+                      border: 'none',
+                      color: '#007bff',
+                      textDecoration: 'underline',
+                      cursor: 'pointer'
+                    }}>
+                  Sign In
+                </button>
+
+              </div>
+          ) : (
+              <SignInModal onSuccessfulSignIn={handleSuccessfulSignIn} />
+          )}
+      </div>
+
+      <div id="postContent">
+        <Container>
+          <Header signedIn={isSignedIn}/>
+          {router.isFallback ? (
+              <PostTitle>Loading…</PostTitle>
+          ) : (
+              <>
+                <PostHeader
+                    title={post.title}
+                    coverImage={post.coverImage}
+                    date={post.date}
+                    author={post.author}
+                />
+                <article className="mb-32" ref={blurContainerRef}>
+                  <Head>
+                    <title>
+                      {post.title} | Next.js Blog Example with {CMS_NAME}
+                    </title>
+                    <meta property="og:image" content={post.ogImage.url} />
+                  </Head>
+                  <PostBody content={post.content} />
+                </article>
+              </>
+          )}
+        </Container>
+      </div>
     </Layout>
   )
 }
@@ -70,6 +134,7 @@ export async function getStaticProps({ params }: Params) {
     'content',
     'ogImage',
     'coverImage',
+    'isPremium'
   ])
   const content = await markdownToHtml(post.content || '')
 

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -30,16 +30,29 @@ const Post = ({ post, morePosts, preview }: Props) => {
   const [isSignedIn, setIsSignedIn] = useState(false);
 
   useEffect(() => {
-    const isUserSignedIn = document.cookie.indexOf('username=admin') >= 0;
-    if (post.isPremium && !isUserSignedIn) {
+    const checkSignInStatus = () => {
+      const isUserSignedIn = document.cookie.indexOf('username=admin') >= 0;
+      setIsSignedIn(isUserSignedIn);
+
       const paywallElement = document.getElementById("paywall");
       if (paywallElement) {
-        paywallElement.style.display = "flex";
+        if (post.isPremium && !isUserSignedIn) {
+          paywallElement.style.display = "flex";
+        } else {
+          paywallElement.style.display = "none";
+        }
       }
+
       if (blurContainerRef.current) {
-        blurContainerRef.current.style.filter = "blur(8px)";
+        blurContainerRef.current.style.filter = post.isPremium && !isUserSignedIn ? "blur(8px)" : "none";
       }
-    }
+    };
+
+    checkSignInStatus();
+    const intervalId = setInterval(checkSignInStatus, 1000); // Check every second, for example
+    return () => {
+      clearInterval(intervalId);
+    };
   }, [post.isPremium]);
 
   const toggleSignInModal = () => {

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -31,7 +31,7 @@ const Post = ({ post, morePosts, preview }: Props) => {
 
   useEffect(() => {
     const isUserSignedIn = document.cookie.indexOf('username=admin') >= 0;
-    if (post.isPremium === 'True' && !isUserSignedIn) {
+    if (post.isPremium && !isUserSignedIn) {
       const paywallElement = document.getElementById("paywall");
       if (paywallElement) {
         paywallElement.style.display = "flex";

--- a/types/post.ts
+++ b/types/post.ts
@@ -11,7 +11,7 @@ type PostType = {
     url: string
   }
   content: string
-  isPremium: string
+  isPremium: boolean
 }
 
 export default PostType

--- a/types/post.ts
+++ b/types/post.ts
@@ -11,6 +11,7 @@ type PostType = {
     url: string
   }
   content: string
+  isPremium: string
 }
 
 export default PostType


### PR DESCRIPTION
- show 'Premium' string in the post preview when a post is premium
- only blur the post content if a user is not logged in (premium user). I wanted users to be able to read the article name and author even if they are not premium (for author/post visibility and potentially better SEO).
- show paywall and login link to modal if content is premium and a user isn't logged in.
- show dummy login form that stores credentials in cookies
- add login button in the Header to allow users to log in or log out and clear cookies at any time 
- if user logs out on the post page, the post re-blurs

Vercel deployment: https://blog-ashy-iota.vercel.app/

dummy login credentials
- username: admin
- password: admin